### PR TITLE
fix: validate Vector3Enhanced

### DIFF
--- a/src/plugin-hyperfy/controls.ts
+++ b/src/plugin-hyperfy/controls.ts
@@ -388,7 +388,7 @@ export class AgentControls extends System {
        const quat = player.base.quaternion;
 
        if (!(pos instanceof THREE.Vector3 || pos instanceof Vector3Enhanced)) {
-            logger.error(`[Controls ${caller}] Invalid state: player.base.position is not a THREE.Vector3.`);
+            logger.error(`[Controls ${caller}] Invalid state: player.base.position must be a THREE.Vector3 or Vector3Enhanced.`);
             return false;
        }
         if (isNaN(pos.x) || isNaN(pos.y) || isNaN(pos.z)) {

--- a/src/plugin-hyperfy/controls.ts
+++ b/src/plugin-hyperfy/controls.ts
@@ -1,6 +1,7 @@
 import { System } from './hyperfy/core/systems/System.js'
 import { logger } from '@elizaos/core';
 import * as THREE from 'three';
+import { Vector3Enhanced } from './hyperfy/core/extras/Vector3Enhanced.js'
 
 // Define Navigation Constants
 const NAVIGATION_TICK_INTERVAL = 100; // ms
@@ -386,7 +387,7 @@ export class AgentControls extends System {
        const pos = player.base.position;
        const quat = player.base.quaternion;
 
-       if (!(pos instanceof THREE.Vector3)) {
+       if (!(pos instanceof THREE.Vector3 || pos instanceof Vector3Enhanced)) {
             logger.error(`[Controls ${caller}] Invalid state: player.base.position is not a THREE.Vector3.`);
             return false;
        }


### PR DESCRIPTION
Currently, the random walk action doesn't work because the player position is a Vector3Enhanced instead of a THREE.Vector3, which causes _validatePlayerState to fail