### PR TITLE
fix: pysics

### DIFF
--- a/src/plugin-hyperfy/loader.ts
+++ b/src/plugin-hyperfy/loader.ts
@@ -147,6 +147,19 @@ export class AgentLoader extends System {
           return this.parseGLB(type, key, arrayBuffer, resolved);
         }
 
+        if (type === 'script') {
+          let code = await response.text();
+
+          // Remove UI creation block
+          code = code.replace(
+            /const \$ui = app\.create\([\s\S]*?app\.add\(\$ui\);?/,
+            ''
+          );
+          const script = this.world.scripts.evaluate(code)
+          this.results.set(key, script)
+          return script
+        }
+
         console.warn(`[AgentLoader] Unsupported type in load(): ${type}`);
         return null;
       })


### PR DESCRIPTION
To make physics work, we need to load the script, but we don't need to create the UI in the node world. In fact, creating the UI there causes errors. As a workaround, this PR uses a hack to strip out any code related to UI creation from the script before evaluating it.


https://github.com/user-attachments/assets/6f3299ae-f1a2-4a16-953b-0065bb50b387

