### PR TITLE
fix: avatar upload issue due to incorrect file format passed to network API

### DIFF
--- a/src/plugin-hyperfy/service.ts
+++ b/src/plugin-hyperfy/service.ts
@@ -313,12 +313,9 @@ export class HyperfyService extends Service {
         if (typeof this.world.network.upload === 'function') {
            console.info(`[Appearance] Calling world.network.upload for ${fullFileNameWithHash}...`);
             try {
-                const uploadPromise = this.world.network.upload({ 
-                    buffer: fileBuffer, 
-                    name: fileName, // Original filename might still be needed by upload func
-                    type: mimeType, 
-                    size: fileBuffer.length,
-                });
+                const fileForUpload = new File([fileBuffer], fileName, { type: mimeType });
+
+                const uploadPromise = this.world.network.upload(fileForUpload);
 
                 // Add a timeout for the upload operation (e.g., 30 seconds)
                 const UPLOAD_TIMEOUT_MS = 30000;


### PR DESCRIPTION
Currently, we’re unable to upload a custom avatar to the server. On the client side, we encounter the following error:

<img width="1003" alt="Screenshot 2025-05-09 at 7 22 46 PM" src="https://github.com/user-attachments/assets/b37b3abf-3b02-469c-a3fc-18230c8ef850" />


And on the server:

<img width="852" alt="Screenshot 2025-05-09 at 7 22 56 PM" src="https://github.com/user-attachments/assets/5b2a361e-29e8-4169-b6c5-7e1d9e75992e" />

This issue occurs because we were passing a plain object with a buffer instead of a proper File instance to the clientNetwork.upload method. This PR wraps the buffer using File before calling the upload API, resolving the error and enabling successful avatar uploads.