### PR TITLE
refactor: replace msgGuard with agentActivityLock using manual enter/exit for accurate agent activity tracking

### DIFF
--- a/src/plugin-hyperfy/behavior-manager.ts
+++ b/src/plugin-hyperfy/behavior-manager.ts
@@ -1,7 +1,7 @@
 import { ChannelType, Content, HandlerCallback, IAgentRuntime, Memory, ModelType, composePromptFromState, createUniqueUuid, logger, parseKeyValueXml } from "@elizaos/core";
 import { HyperfyService } from "./service";
 import { autoTemplate } from "./templates";
-import { msgGuard } from "./guards";
+import { agentActivityLock } from "./guards";
 
 const TIME_INTERVAL_MIN = 15000; // 15 seconds
 const TIME_INTERVAL_MAX = 30000; // 30 seconds
@@ -70,7 +70,7 @@ export class BehaviorManager {
   private async executeBehavior(): Promise<void> {
     // TODO: There may be slow post-processing in the bootstrap plugin's message handler.
     // Investigate long tail after message handling, especially in emitEvent or runtime methods.
-    if (msgGuard.isActive()) {
+    if (agentActivityLock.isActive()) {
       logger.info("[BehaviorManager] Skipping behavior — message activity in progress");
       return;
     }

--- a/src/plugin-hyperfy/guards.ts
+++ b/src/plugin-hyperfy/guards.ts
@@ -4,7 +4,7 @@
  * Used to prevent behavior execution during active message processing.
  */
 
-export class MessageActivityGuard {
+export class AgentActivityLock {
     private count = 0;
   
     isActive(): boolean {
@@ -31,5 +31,5 @@ export class MessageActivityGuard {
   
 
 
-export const msgGuard = new MessageActivityGuard();
+export const agentActivityLock = new AgentActivityLock();
   

--- a/src/plugin-hyperfy/guards.ts
+++ b/src/plugin-hyperfy/guards.ts
@@ -6,20 +6,29 @@
 
 export class MessageActivityGuard {
     private count = 0;
-
+  
     isActive(): boolean {
-        return this.count > 0;
+      return this.count > 0;
     }
-
+  
+    enter() {
+      this.count++;
+    }
+  
+    exit() {
+      this.count = Math.max(0, this.count - 1);
+    }
+  
     async run<T>(fn: () => Promise<T>): Promise<T> {
-        this.count++;
-        try {
+      this.enter();
+      try {
         return await fn();
-        } finally {
-        this.count--;
-        }
+      } finally {
+        this.exit();
+      }
     }
-}
+  }
+  
 
 
 export const msgGuard = new MessageActivityGuard();

--- a/src/plugin-hyperfy/message-manager.ts
+++ b/src/plugin-hyperfy/message-manager.ts
@@ -1,6 +1,6 @@
 import { ChannelType, Content, EventType, HandlerCallback, IAgentRuntime, Memory, UUID, createUniqueUuid, formatMessages, getEntityDetails } from "@elizaos/core";
 import { HyperfyService } from "./service";
-import { msgGuard } from "./guards";
+import { agentActivityLock } from "./guards";
 import { messageHandlerTemplate } from "./templates";
 
 export class MessageManager {
@@ -16,7 +16,7 @@ export class MessageManager {
 
   async handleMessage(msg): Promise<void> {
     // maybe a thinking emote here?
-    await msgGuard.run(async () => {
+    await agentActivityLock.run(async () => {
       const service = this.getService();
       const world = service.getWorld();
       const agentPlayerId = world.entities.player.data.id // Get agent's ID
@@ -151,14 +151,14 @@ export class MessageManager {
 
         // Emit the MESSAGE_RECEIVED event to trigger the message handler
         console.info(`[Hyperfy Chat] Emitting MESSAGE_RECEIVED event for message: ${messageId}`)
-        msgGuard.enter();
+        agentActivityLock.enter();
         await this.runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
             runtime: this.runtime,
             message: memory,
             callback: callback,
             source: 'hyperfy',
             onComplete: () => {
-              msgGuard.exit();
+              agentActivityLock.exit();
             }
           },
         )

--- a/src/plugin-hyperfy/message-manager.ts
+++ b/src/plugin-hyperfy/message-manager.ts
@@ -151,12 +151,14 @@ export class MessageManager {
 
         // Emit the MESSAGE_RECEIVED event to trigger the message handler
         console.info(`[Hyperfy Chat] Emitting MESSAGE_RECEIVED event for message: ${messageId}`)
+        msgGuard.enter();
         await this.runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
             runtime: this.runtime,
             message: memory,
             callback: callback,
             source: 'hyperfy',
             onComplete: () => {
+              msgGuard.exit();
             }
           },
         )

--- a/src/plugin-hyperfy/voice-manager.ts
+++ b/src/plugin-hyperfy/voice-manager.ts
@@ -1,7 +1,7 @@
 import { ChannelType, Content, HandlerCallback, IAgentRuntime, Memory, ModelType, UUID, createUniqueUuid, getWavHeader, logger } from "@elizaos/core";
 import { HyperfyService } from "./service";
 import { convertToAudioBuffer } from "./utils";
-import { msgGuard } from "./guards";
+import { agentActivityLock } from "./guards";
 
 type LiveKitAudioData = {
   participant: string;
@@ -88,7 +88,7 @@ export class VoiceManager {
     }
 
     this.transcriptionTimeout = setTimeout(async () => {
-      await msgGuard.run(async () => {
+      await agentActivityLock.run(async () => {
         this.processingVoice = true;
         try {
           await this.processTranscription(playerId);
@@ -233,14 +233,14 @@ export class VoiceManager {
         }
       };
 
-      msgGuard.enter();
+      agentActivityLock.enter();
       // Emit voice-specific events
       this.runtime.emitEvent(['VOICE_MESSAGE_RECEIVED'], {
         runtime: this.runtime,
         message: memory,
         callback,
         onComplete: () => {
-          msgGuard.exit();
+          agentActivityLock.exit();
         },
       });
     } catch (error) {

--- a/src/plugin-hyperfy/voice-manager.ts
+++ b/src/plugin-hyperfy/voice-manager.ts
@@ -233,11 +233,15 @@ export class VoiceManager {
         }
       };
 
+      msgGuard.enter();
       // Emit voice-specific events
       this.runtime.emitEvent(['VOICE_MESSAGE_RECEIVED'], {
         runtime: this.runtime,
         message: memory,
         callback,
+        onComplete: () => {
+          msgGuard.exit();
+        },
       });
     } catch (error) {
       console.error('Error processing voice message:', error);


### PR DESCRIPTION
This PR replaces `msgGuard` with a more descriptive and flexible `agentActivityLock`, and refactors the usage from the old `.run()` pattern to explicit `enter()` and `exit()` calls. This allows us to track agent activity more precisely, especially when handling async flows like emitEvent with onComplete callbacks.
