### PR TITLE
Fix agent communication bug due to missing message fields

### DIFF
--- a/src/plugin-hyperfy/actions/build.ts
+++ b/src/plugin-hyperfy/actions/build.ts
@@ -259,16 +259,8 @@ ${summary}
             break;
         }
         if (description) {
-            const agentPlayerId = world.entities.player.data.id
-            const agentPlayerName = service.getEntityName(agentPlayerId) || world.entities.player.data?.name || 'Hyperliza'      
-            world.chat.add(
-                {
-                    body: description,
-                    fromId: agentPlayerId,
-                    from: agentPlayerName,
-                },
-                true
-            )
+          const messageManager = service.getMessageManager();
+          messageManager.sendMessage(description);
         }
       }
       const summaryText = operationResults.operations.map(op => {

--- a/src/plugin-hyperfy/managers/message-manager.ts
+++ b/src/plugin-hyperfy/managers/message-manager.ts
@@ -2,6 +2,8 @@ import { ChannelType, Entity, Content, HandlerCallback, IAgentRuntime, Memory, U
 import { HyperfyService } from "../service";
 import { agentActivityLock } from "./guards";
 import { hyperfyEventType } from "../events";
+import moment from 'moment'
+import { uuid } from '../hyperfy/src/core/utils';
 
 export class MessageManager {
   private runtime: IAgentRuntime;
@@ -165,9 +167,11 @@ export class MessageManager {
 
       world.chat.add(
         {
+          id: uuid(),
           body: text,
           fromId: agentPlayerId,
           from: agentPlayerName,
+          createdAt: moment().toISOString()
         },
         true
       )


### PR DESCRIPTION
related: https://github.com/elizaOS/eliza-3d-hyperfy-starter/issues/62

Agents were not communicating with each other because the message object was missing the id and createdAt fields.
This PR fixes the issue by ensuring these fields are included in the message payload.

result:

https://github.com/user-attachments/assets/e649363d-e203-4cfc-be3d-ca0f44dfc34e

